### PR TITLE
composing emitter to use multiple emitter together

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <version>3.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.6.4</version>

--- a/src/main/java/com/metamx/emitter/core/ComposingEmitter.java
+++ b/src/main/java/com/metamx/emitter/core/ComposingEmitter.java
@@ -1,0 +1,104 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package com.metamx.emitter.core;
+
+import com.google.common.base.Preconditions;
+import com.metamx.common.lifecycle.LifecycleStart;
+import com.metamx.common.lifecycle.LifecycleStop;
+import com.metamx.common.logger.Logger;
+
+import java.io.IOException;
+import java.util.List;
+
+public class ComposingEmitter implements Emitter
+{
+  private static Logger log = new Logger(ComposingEmitter.class);
+
+  private final List<Emitter> emitters;
+
+  public ComposingEmitter(List<Emitter> emitters)
+  {
+    this.emitters = Preconditions.checkNotNull(emitters, "null emitters");
+  }
+
+  @Override
+  @LifecycleStart
+  public void start()
+  {
+    log.info("Starting Composing Emitter.");
+
+    for (Emitter e : emitters) {
+      log.info("Starting emitter %s.", e.getClass().getName());
+      e.start();
+    }
+  }
+
+  @Override
+  public void emit(Event event)
+  {
+    for (Emitter e : emitters) {
+      e.emit(event);
+    }
+  }
+
+  @Override
+  public void flush() throws IOException
+  {
+    boolean fail = false;
+    log.info("Flushing Composing Emitter.");
+
+    for (Emitter e : emitters) {
+      try {
+        log.info("Flushing emitter %s.", e.getClass().getName());
+        e.flush();
+      } catch (IOException ex) {
+        log.error(ex, "Failed to flush emitter [%s]", e.getClass().getName());
+        fail = true;
+      }
+    }
+
+    if(fail) {
+      throw new IOException("failed to flush one or more emitters");
+    }
+  }
+
+  @Override
+  @LifecycleStop
+  public void close() throws IOException
+  {
+    boolean fail = false;
+    log.info("Closing Composing Emitter.");
+
+    for (Emitter e : emitters) {
+      try {
+        log.info("Closing emitter %s.", e.getClass().getName());
+        e.close();
+      }
+      catch (IOException ex) {
+        log.error(ex, "Failed to close emitter [%s]", e.getClass().getName());
+        fail = true;
+      }
+    }
+
+    if(fail) {
+      throw new IOException("failed to close one or more emitters");
+    }
+  }
+}

--- a/src/test/java/com/metamx/emitter/core/ComposingEmitterTest.java
+++ b/src/test/java/com/metamx/emitter/core/ComposingEmitterTest.java
@@ -1,0 +1,100 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package com.metamx.emitter.core;
+
+import com.google.common.collect.ImmutableList;
+import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+public class ComposingEmitterTest
+{
+
+  private List<Emitter> childEmitters;
+  private ComposingEmitter composingEmitter;
+
+  @Before
+  public void setup()
+  {
+    this.childEmitters = ImmutableList.of(
+        EasyMock.createMock(Emitter.class),
+        EasyMock.createMock(Emitter.class)
+    );
+    this.composingEmitter = new ComposingEmitter(childEmitters);
+  }
+
+  @Test
+  public void testStart()
+  {
+    for (Emitter emitter : childEmitters) {
+      emitter.start();
+      EasyMock.replay(emitter);
+    }
+
+    composingEmitter.start();
+  }
+
+  @Test
+  public void testEmit()
+  {
+    Event e = EasyMock.createMock(Event.class);
+
+    for (Emitter emitter : childEmitters) {
+      emitter.emit(e);
+      EasyMock.replay(emitter);
+    }
+
+    composingEmitter.emit(e);
+  }
+
+  @Test
+  public void testFlush() throws IOException
+  {
+    for (Emitter emitter : childEmitters) {
+      emitter.flush();
+      EasyMock.replay(emitter);
+    }
+
+    composingEmitter.flush();
+  }
+
+  @Test
+  public void testClose() throws IOException
+  {
+    for (Emitter emitter : childEmitters) {
+      emitter.close();
+      EasyMock.replay(emitter);
+    }
+
+    composingEmitter.close();
+  }
+
+  @After
+  public void tearDown()
+  {
+    for (Emitter emitter : childEmitters) {
+      EasyMock.verify(emitter);
+    }
+  }
+}


### PR DESCRIPTION
This allows you to have multiple emitters configured at the same time. This can be useful if you want to have multiple potential landing points for your emitter messages.
For example we use this for sending druid metrics to another druid cluster via a "http" emitter and to a hosted monitoring system via another custom emitter..