### PR TITLE
add time out to flush

### DIFF
--- a/src/main/java/com/metamx/emitter/core/Emitters.java
+++ b/src/main/java/com/metamx/emitter/core/Emitters.java
@@ -72,6 +72,10 @@ public class Emitters
     httpMap.put("recipientBaseUrl", baseUrl);
     httpMap.put("flushMillis", Long.parseLong(props.getProperty("com.metamx.emitter.flushMillis", "60000")));
     httpMap.put("flushCount", Integer.parseInt(props.getProperty("com.metamx.emitter.flushCount", "300")));
+    /**
+     * The defaultValue for "com.metamx.emitter.http.flushTimeOut" must be same as {@link HttpEmitterConfig.DEFAULT_FLUSH_TIME_OUT}
+     * */
+    httpMap.put("flushTimeOut", Long.parseLong(props.getProperty("com.metamx.emitter.http.flushTimeOut", String.valueOf(Long.MAX_VALUE))));
     if (props.containsKey("com.metamx.emitter.http.basicAuthentication")) {
       httpMap.put("basicAuthentication", props.getProperty("com.metamx.emitter.http.basicAuthentication"));
     }

--- a/src/main/java/com/metamx/emitter/core/HttpEmitterConfig.java
+++ b/src/main/java/com/metamx/emitter/core/HttpEmitterConfig.java
@@ -27,6 +27,7 @@ public class HttpEmitterConfig
 {
   private static final int DEFAULT_MAX_BATCH_SIZE = 5 * 1024 * 1024;
   private static final long DEFAULT_MAX_BUFFER_SIZE = 250 * 1024 * 1024;
+  private static final long DEFAULT_FLUSH_TIME_OUT = Long.MAX_VALUE; // do not time out in case flushTimeOut is not set
   private static final String DEFAULT_BASIC_AUTHENTICATION = null;
   private static final BatchingStrategy DEFAULT_BATCHING_STRATEGY = BatchingStrategy.ARRAY;
 
@@ -37,6 +38,10 @@ public class HttpEmitterConfig
   @Min(0)
   @JsonProperty
   private int flushCount = 500;
+
+  @Min(0)
+  @JsonProperty
+  private long flushTimeOut = DEFAULT_FLUSH_TIME_OUT;
 
   @NotNull
   @JsonProperty
@@ -67,6 +72,7 @@ public class HttpEmitterConfig
     this(
         flushMillis,
         flushCount,
+        DEFAULT_FLUSH_TIME_OUT,
         recipientBaseUrl,
         DEFAULT_BASIC_AUTHENTICATION,
         DEFAULT_BATCHING_STRATEGY,
@@ -86,6 +92,7 @@ public class HttpEmitterConfig
     this(
         flushMillis,
         flushCount,
+        DEFAULT_FLUSH_TIME_OUT,
         recipientBaseUrl,
         DEFAULT_BASIC_AUTHENTICATION,
         DEFAULT_BATCHING_STRATEGY,
@@ -104,8 +111,32 @@ public class HttpEmitterConfig
       long maxBufferSize
   )
   {
+    this(
+        flushMillis,
+        flushCount,
+        DEFAULT_FLUSH_TIME_OUT,
+        recipientBaseUrl,
+        basicAuthentication,
+        batchingStrategy,
+        maxBatchSize,
+        maxBufferSize
+    );
+  }
+
+  public HttpEmitterConfig(
+      long flushMillis,
+      int flushCount,
+      long flushTimeOut,
+      String recipientBaseUrl,
+      String basicAuthentication,
+      BatchingStrategy batchingStrategy,
+      int maxBatchSize,
+      long maxBufferSize
+  )
+  {
     this.flushMillis = flushMillis;
     this.flushCount = flushCount;
+    this.flushTimeOut = flushTimeOut;
     this.recipientBaseUrl = recipientBaseUrl;
     this.basicAuthentication = basicAuthentication;
     this.batchingStrategy = batchingStrategy;
@@ -121,6 +152,10 @@ public class HttpEmitterConfig
   public int getFlushCount()
   {
     return flushCount;
+  }
+
+  public long getFlushTimeOut() {
+    return flushTimeOut;
   }
 
   public String getRecipientBaseUrl()

--- a/src/test/java/com/metamx/emitter/core/HttpEmitterConfigTest.java
+++ b/src/test/java/com/metamx/emitter/core/HttpEmitterConfigTest.java
@@ -40,6 +40,7 @@ public class HttpEmitterConfigTest
     Assert.assertEquals(BatchingStrategy.ARRAY, config.getBatchingStrategy());
     Assert.assertEquals(5 * 1024 * 1024, config.getMaxBatchSize());
     Assert.assertEquals(250 * 1024 * 1024, config.getMaxBufferSize());
+    Assert.assertEquals(Long.MAX_VALUE, config.getFlushTimeOut());
   }
 
   @Test
@@ -53,6 +54,7 @@ public class HttpEmitterConfigTest
     props.setProperty("com.metamx.emitter.http.batchingStrategy", "newlines");
     props.setProperty("com.metamx.emitter.http.maxBatchSize", "4");
     props.setProperty("com.metamx.emitter.http.maxBufferSize", "8");
+    props.setProperty("com.metamx.emitter.http.flushTimeOut", "1000");
 
     final ObjectMapper objectMapper = new ObjectMapper();
     final HttpEmitterConfig config = objectMapper.convertValue(Emitters.makeHttpMap(props), HttpEmitterConfig.class);
@@ -64,5 +66,6 @@ public class HttpEmitterConfigTest
     Assert.assertEquals(BatchingStrategy.NEWLINES, config.getBatchingStrategy());
     Assert.assertEquals(4, config.getMaxBatchSize());
     Assert.assertEquals(8, config.getMaxBufferSize());
+    Assert.assertEquals(1000, config.getFlushTimeOut());
   }
 }


### PR DESCRIPTION
If there are lot of messages in buffer during flushing it can take prevent emitter from being closed. Consequently, the peon process can get stuck for a considerable amount of time during shutdown. In one of the internal projects we found that peon process were taking around 20-40 minutes to shutdown after reporting SUCCESS status as it had to flush the entire buffer (default size is 250 MB).

These can happen for various reasons, for example - the HTTP end point may not be available and thus for each batch of data the HttpClient will timeout or the HTTP end point is slow in accepting the events.

This PR is a defensive way of preventing against bad HTTPEndPoints and does not changes the default behavior. New configuration "com.metamx.emitter.http.flushTimeOut" is exposed, default value is -1 and any negative value would mean do not timeout. Behavior for positive values is defined by latch.await(long timeout, TimeUnit.MILLISECONDS)