### PR TITLE
Ability to configure LogginerEmitter to only emit metrics or only alerts or both

### DIFF
--- a/src/main/java/com/metamx/emitter/core/LoggingEmitterConfig.java
+++ b/src/main/java/com/metamx/emitter/core/LoggingEmitterConfig.java
@@ -24,6 +24,7 @@ import javax.validation.constraints.NotNull;
  */
 public class LoggingEmitterConfig
 {
+
   @NotNull
   @JsonProperty
   private String loggerClass = LoggingEmitter.class.getName();
@@ -31,6 +32,10 @@ public class LoggingEmitterConfig
   @NotNull
   @JsonProperty
   private String logLevel = "info";
+
+  @NotNull
+  @JsonProperty
+  private String eventsToLog = "ALL";
 
   public String getLoggerClass()
   {
@@ -52,12 +57,23 @@ public class LoggingEmitterConfig
     this.logLevel = logLevel;
   }
 
+  public String getEventsToLog()
+  {
+    return eventsToLog;
+  }
+
+  public void setEventsToLog(String eventsToLog)
+  {
+    this.eventsToLog = eventsToLog;
+  }
+
   @Override
   public String toString()
   {
     return "LoggingEmitterConfig{" +
            "loggerClass='" + loggerClass + '\'' +
            ", logLevel='" + logLevel + '\'' +
+           ", eventsToLog='" + eventsToLog + '\'' +
            '}';
   }
 }

--- a/src/test/java/com/metamx/emitter/core/HttpEmitterConfigTest.java
+++ b/src/test/java/com/metamx/emitter/core/HttpEmitterConfigTest.java
@@ -17,25 +17,20 @@
 package com.metamx.emitter.core;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.Properties;
 
 public class HttpEmitterConfigTest
 {
   @Test
-  public void testDefaults()
+  public void testDefaults() throws Exception
   {
-    final Properties props = new Properties();
-    props.put("com.metamx.emitter.http.url", "http://example.com/");
-
     final ObjectMapper objectMapper = new ObjectMapper();
-    final HttpEmitterConfig config = objectMapper.convertValue(Emitters.makeHttpMap(props), HttpEmitterConfig.class);
+    final HttpEmitterConfig config = objectMapper.readValue("{}", HttpEmitterConfig.class);
 
     Assert.assertEquals(60000, config.getFlushMillis());
-    Assert.assertEquals(300, config.getFlushCount());
-    Assert.assertEquals("http://example.com/", config.getRecipientBaseUrl());
+    Assert.assertEquals(500, config.getFlushCount());
+    Assert.assertNull(config.getRecipientBaseUrl());
     Assert.assertEquals(null, config.getBasicAuthentication());
     Assert.assertEquals(BatchingStrategy.ARRAY, config.getBatchingStrategy());
     Assert.assertEquals(5 * 1024 * 1024, config.getMaxBatchSize());
@@ -44,20 +39,28 @@ public class HttpEmitterConfigTest
   }
 
   @Test
-  public void testSettingEverything()
+  public void testSettingEverything() throws Exception
   {
-    final Properties props = new Properties();
-    props.setProperty("com.metamx.emitter.flushMillis", "1");
-    props.setProperty("com.metamx.emitter.flushCount", "2");
-    props.setProperty("com.metamx.emitter.http.url", "http://example.com/");
-    props.setProperty("com.metamx.emitter.http.basicAuthentication", "a:b");
-    props.setProperty("com.metamx.emitter.http.batchingStrategy", "newlines");
-    props.setProperty("com.metamx.emitter.http.maxBatchSize", "4");
-    props.setProperty("com.metamx.emitter.http.maxBufferSize", "8");
-    props.setProperty("com.metamx.emitter.http.flushTimeOut", "1000");
-
     final ObjectMapper objectMapper = new ObjectMapper();
-    final HttpEmitterConfig config = objectMapper.convertValue(Emitters.makeHttpMap(props), HttpEmitterConfig.class);
+    final HttpEmitterConfig config =
+        objectMapper.readValue(
+            objectMapper.writeValueAsString(
+                objectMapper.readValue(
+                    "{\n"
+                    + "  \"flushMillis\": 1,\n"
+                    + "  \"flushCount\": 2,\n"
+                    + "  \"flushTimeOut\": 1000,\n"
+                    + "  \"recipientBaseUrl\": \"http://example.com/\",\n"
+                    + "  \"basicAuthentication\": \"a:b\",\n"
+                    + "  \"batchingStrategy\": \"NEWLINES\",\n"
+                    + "  \"maxBatchSize\": 4,\n"
+                    + "  \"maxBufferSize\": 8\n"
+                    + "}",
+                    HttpEmitterConfig.class
+                )
+            ),
+            HttpEmitterConfig.class
+        );
 
     Assert.assertEquals(1, config.getFlushMillis());
     Assert.assertEquals(2, config.getFlushCount());

--- a/src/test/java/com/metamx/emitter/core/LoggingEmitterConfigTest.java
+++ b/src/test/java/com/metamx/emitter/core/LoggingEmitterConfigTest.java
@@ -17,41 +17,41 @@
 package com.metamx.emitter.core;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.Properties;
 
 public class LoggingEmitterConfigTest
 {
   @Test
-  public void testDefaults()
+  public void testDefaults() throws Exception
   {
-    final Properties props = new Properties();
     final ObjectMapper objectMapper = new ObjectMapper();
-    final LoggingEmitterConfig config = objectMapper.convertValue(
-        Emitters.makeLoggingMap(props),
+    final LoggingEmitterConfig config = objectMapper.readValue(
+        "{}",
         LoggingEmitterConfig.class
     );
 
     Assert.assertEquals(LoggingEmitter.class.getName(), config.getLoggerClass());
-    Assert.assertEquals("debug", config.getLogLevel());
+    Assert.assertEquals("info", config.getLogLevel());
   }
 
   @Test
-  public void testSettingEverything()
+  public void testSettingEverything() throws Exception
   {
-    final Properties props = new Properties();
-    props.setProperty("com.metamx.emitter.logging.class", "Foo");
-    props.setProperty("com.metamx.emitter.logging.level", "INFO");
-
     final ObjectMapper objectMapper = new ObjectMapper();
-    final LoggingEmitterConfig config = objectMapper.convertValue(
-        Emitters.makeLoggingMap(props),
+    final LoggingEmitterConfig config = objectMapper.readValue(
+        objectMapper.writeValueAsString(
+            objectMapper.readValue(
+                "{ \"loggerClass\": \"Foo\","
+                + "\"logLevel\": \"debug\" "
+                + "}",
+                LoggingEmitterConfig.class
+            )
+        ),
         LoggingEmitterConfig.class
     );
 
     Assert.assertEquals("Foo", config.getLoggerClass());
-    Assert.assertEquals("INFO", config.getLogLevel());
+    Assert.assertEquals("debug", config.getLogLevel());
   }
 }

--- a/src/test/java/com/metamx/emitter/core/LoggingEmitterConfigTest.java
+++ b/src/test/java/com/metamx/emitter/core/LoggingEmitterConfigTest.java
@@ -33,6 +33,7 @@ public class LoggingEmitterConfigTest
 
     Assert.assertEquals(LoggingEmitter.class.getName(), config.getLoggerClass());
     Assert.assertEquals("info", config.getLogLevel());
+    Assert.assertEquals("ALL", config.getEventsToLog());
   }
 
   @Test
@@ -43,7 +44,8 @@ public class LoggingEmitterConfigTest
         objectMapper.writeValueAsString(
             objectMapper.readValue(
                 "{ \"loggerClass\": \"Foo\","
-                + "\"logLevel\": \"debug\" "
+                + "\"logLevel\": \"debug\","
+                + "\"eventsToLog\": \"alerts\" "
                 + "}",
                 LoggingEmitterConfig.class
             )
@@ -53,5 +55,6 @@ public class LoggingEmitterConfigTest
 
     Assert.assertEquals("Foo", config.getLoggerClass());
     Assert.assertEquals("debug", config.getLogLevel());
+    Assert.assertEquals("alerts", config.getEventsToLog());
   }
 }


### PR DESCRIPTION
most of the monitoring systems can't handle the stack-traces druid alerts contain, however they contain useful information.. we want the ability to push metrics to other systems and yet be able to log just the alerts in the process logs. This PR combined with composing emitter enables doing that with other emitters such as http post.

also, a bit of cleanup in Logging/Http EmitterConfigTest
