### PR TITLE
BACKEND-624: CloudServiceEmitter

### DIFF
--- a/src/main/java/com/metamx/emitter/service/CloudServiceEmitter.java
+++ b/src/main/java/com/metamx/emitter/service/CloudServiceEmitter.java
@@ -23,7 +23,7 @@ import com.metamx.emitter.core.Emitter;
 public class CloudServiceEmitter extends ServiceEmitter
 {
   private static final String ENV_DIMENSION = "env";
-  private static final String LOCATION_DIMENSION = "location";
+  private static final String LOCATION_DIMENSION = "loc";
   private static final String ZONE_DIMENSION = "zone";
 
   public CloudServiceEmitter(

--- a/src/main/java/com/metamx/emitter/service/CloudServiceEmitter.java
+++ b/src/main/java/com/metamx/emitter/service/CloudServiceEmitter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2012 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.metamx.emitter.service;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.metamx.emitter.core.Emitter;
+
+public class CloudServiceEmitter extends ServiceEmitter
+{
+  private static final String ENV_DIMENSION = "env";
+  private static final String LOCATION_DIMENSION = "location";
+  private static final String ZONE_DIMENSION = "zone";
+
+  public CloudServiceEmitter(
+      String service,
+      String host,
+      String env,
+      String location,
+      String zone,
+      Emitter emitter
+  )
+  {
+    this(service, host, env, location, zone, emitter, ImmutableMap.<String, String>of());
+  }
+
+  public CloudServiceEmitter(
+      String service,
+      String host,
+      String env,
+      String location,
+      String zone,
+      Emitter emitter,
+      ImmutableMap<String, String> otherServiceDimensions
+  )
+  {
+    super(service, host, emitter, new ImmutableMap.Builder<String, String>()
+        .put(ENV_DIMENSION, Preconditions.checkNotNull(env))
+        .put(LOCATION_DIMENSION, Preconditions.checkNotNull(location))
+        .put(ZONE_DIMENSION, Preconditions.checkNotNull(zone))
+        .putAll(otherServiceDimensions)
+        .build());
+  }
+
+  public String getEnv() {
+    return serviceDimensions.get(ENV_DIMENSION);
+  }
+
+  public String getLocation() {
+    return serviceDimensions.get(LOCATION_DIMENSION);
+  }
+
+  public String getZone() {
+    return serviceDimensions.get(ZONE_DIMENSION);
+  }
+}
+

--- a/src/main/java/com/metamx/emitter/service/ServiceEmitter.java
+++ b/src/main/java/com/metamx/emitter/service/ServiceEmitter.java
@@ -27,8 +27,8 @@ import java.io.IOException;
 
 public class ServiceEmitter implements Emitter
 {
-  private final ImmutableMap<String, String> serviceDimensions;
-  private final Emitter emitter;
+  protected final ImmutableMap<String, String> serviceDimensions;
+  protected final Emitter emitter;
 
   public ServiceEmitter(String service, String host, Emitter emitter)
   {

--- a/src/main/java/com/metamx/emitter/service/ServiceEmitter.java
+++ b/src/main/java/com/metamx/emitter/service/ServiceEmitter.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 public class ServiceEmitter implements Emitter
 {
   protected final ImmutableMap<String, String> serviceDimensions;
-  protected final Emitter emitter;
+  private final Emitter emitter;
 
   public ServiceEmitter(String service, String host, Emitter emitter)
   {

--- a/src/test/java/com/metamx/emitter/service/CloudServiceEmitterTest.java
+++ b/src/test/java/com/metamx/emitter/service/CloudServiceEmitterTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.metamx.emitter.service;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CloudServiceEmitterTest
+{
+  @Test
+  public void testBaseConstructorParams() throws Exception
+  {
+    CloudServiceEmitter cse = new CloudServiceEmitter("service", "host", "env", "location", "zone", null);
+    Assert.assertEquals("Services do not match", "service", cse.getService());
+    Assert.assertEquals("Hosts do not match", "host", cse.getHost());
+    Assert.assertEquals("Envs do not match", "env", cse.getEnv());
+    Assert.assertEquals("Locations do not match", "location", cse.getLocation());
+    Assert.assertEquals("Zones do not match", "zone", cse.getZone());
+  }
+
+  @Test
+  public void testOtherDimensions() throws Exception
+  {
+    CloudServiceEmitter cse = new CloudServiceEmitter(
+        "service",
+        "host",
+        "env",
+        "location",
+        "zone",
+        null,
+        ImmutableMap.<String, String>of("test", "value")
+    );
+    Assert.assertEquals("Other dimensions do not match", "value", cse.serviceDimensions.get("test"));
+  }
+
+}


### PR DESCRIPTION
### CloudServiceEmitter

1. extends ServiceEmitter

2. provides additional required service dimensions: env(dev/prod), location(aws/gcp), zone(us-east/us-west)

and unit tests

**Extra bandwidth**:
Extra: ~50 bytes per event
Extra: ~20 bytes per compressed event
Total: ~180K events per second
Extra total bandwidth: ~3.5MB/s == **28Mbit/s**
Druid: ~87K events per second
Extra druid bandwidth: ~1.7MB/s == **13Mbit/s**

**Extra storage**:
Avg. event size is 690 bytes
Extra event storage is **~7%**
