### PR TITLE
Dependencies update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.metamx</groupId>
         <artifactId>oss-parent</artifactId>
-        <version>1</version>
+        <version>3</version>
     </parent>
 
     <artifactId>emitter</artifactId>
@@ -55,14 +55,14 @@
     </scm>
 
     <properties>
-        <http-client.version>1.0.6</http-client.version>
+        <http-client.version>1.1.0</http-client.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.metamx</groupId>
             <artifactId>java-util</artifactId>
-            <version>0.27.12</version>
+            <version>0.28.2</version>
         </dependency>
         <dependency>
             <groupId>com.metamx</groupId>
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>14.0.1</version>
+            <version>16.0.1</version>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>
@@ -83,17 +83,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.1.2</version>
+            <version>2.6.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.1.3</version>
+            <version>2.6.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.1.3</version>
+            <version>2.6.7</version>
         </dependency>
 
         <!-- Tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
 
     <properties>
         <http-client.version>1.1.0</http-client.version>
+        <jackson.version>2.4.6</jackson.version>
     </properties>
 
     <dependencies>
@@ -83,17 +84,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.6.7</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.6.7</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.7</version>
+            <version>${jackson.version}</version>
         </dependency>
 
         <!-- Tests -->


### PR DESCRIPTION
Dependencies were updated on the latest versions of com.metamx artifacts and the same versions of other dependencies as transient versions from java-util and http-client.
here is the dependency tree before the update:
```
[INFO] com.metamx:emitter:jar:0.4.2-SNAPSHOT
[INFO] +- com.metamx:java-util:jar:0.27.12:compile
[INFO] |  +- org.slf4j:slf4j-api:jar:1.6.4:compile
[INFO] |  +- org.skife.config:config-magic:jar:0.9:compile
[INFO] |  |  \- (org.slf4j:slf4j-api:jar:1.5.6:compile - omitted for conflict with 1.6.4)
[INFO] |  +- (com.google.guava:guava:jar:16.0.1:compile - omitted for conflict with 14.0.1)
[INFO] |  +- (com.fasterxml.jackson.core:jackson-annotations:jar:2.1.4:compile - omitted for conflict with 2.1.2)
[INFO] |  +- (com.fasterxml.jackson.core:jackson-core:jar:2.1.4:compile - omitted for conflict with 2.1.3)
[INFO] |  +- (com.fasterxml.jackson.core:jackson-databind:jar:2.1.4:compile - omitted for conflict with 2.1.3)
[INFO] |  +- net.sf.opencsv:opencsv:jar:2.3:compile
[INFO] |  +- joda-time:joda-time:jar:1.6:compile
[INFO] |  +- org.mozilla:rhino:jar:1.7R5:compile
[INFO] |  \- com.jayway.jsonpath:json-path:jar:2.1.0:compile
[INFO] |     \- (org.slf4j:slf4j-api:jar:1.7.13:compile - omitted for conflict with 1.6.4)
[INFO] +- com.metamx:http-client:jar:1.0.6:compile
[INFO] |  +- (com.metamx:java-util:jar:0.27.4:compile - omitted for conflict with 0.27.12)
[INFO] |  +- io.netty:netty:jar:3.10.4.Final:compile
[INFO] |  \- (com.google.guava:guava:jar:16.0.1:compile - omitted for duplicate)
[INFO] +- com.google.guava:guava:jar:14.0.1:compile
[INFO] +- javax.validation:validation-api:jar:1.1.0.Final:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.1.2:compile
[INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.1.3:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.1.3:compile
[INFO] |  +- (com.fasterxml.jackson.core:jackson-annotations:jar:2.1.2:compile - omitted for duplicate)
[INFO] |  \- (com.fasterxml.jackson.core:jackson-core:jar:2.1.3:compile - omitted for duplicate)
[INFO] +- junit:junit:jar:4.8.1:test
[INFO] +- org.easymock:easymock:jar:3.3:test
[INFO] |  +- cglib:cglib-nodep:jar:3.1:test
[INFO] |  \- org.objenesis:objenesis:jar:2.1:test
[INFO] +- org.slf4j:slf4j-simple:jar:1.7.25:test
[INFO] |  \- (org.slf4j:slf4j-api:jar:1.7.25:test - omitted for conflict with 1.6.4)
[INFO] \- com.metamx:http-client:test-jar:tests:1.0.6:test
[INFO]    +- (com.metamx:java-util:jar:0.27.4:test - omitted for conflict with 0.27.12)
[INFO]    +- (io.netty:netty:jar:3.10.4.Final:test - omitted for duplicate)
[INFO]    \- (com.google.guava:guava:jar:16.0.1:test - omitted for conflict with 14.0.1)
```
And after the update:
```
[INFO] com.metamx:emitter:jar:0.4.2-SNAPSHOT
[INFO] +- com.metamx:java-util:jar:0.28.2:compile
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.22:compile
[INFO] |  +- org.skife.config:config-magic:jar:0.17:compile
[INFO] |  +- (com.google.guava:guava:jar:16.0.1:compile - omitted for duplicate)
[INFO] |  +- (com.fasterxml.jackson.core:jackson-annotations:jar:2.6.7:compile - omitted for duplicate)
[INFO] |  +- (com.fasterxml.jackson.core:jackson-core:jar:2.6.7:compile - omitted for duplicate)
[INFO] |  +- (com.fasterxml.jackson.core:jackson-databind:jar:2.6.7:compile - omitted for duplicate)
[INFO] |  +- net.sf.opencsv:opencsv:jar:2.3:compile
[INFO] |  +- joda-time:joda-time:jar:2.9.7:compile
[INFO] |  +- org.mozilla:rhino:jar:1.7R5:compile
[INFO] |  \- com.jayway.jsonpath:json-path:jar:2.1.0:compile
[INFO] +- com.metamx:http-client:jar:1.1.0:compile
[INFO] |  +- (com.metamx:java-util:jar:0.28.2:compile - omitted for duplicate)
[INFO] |  +- io.netty:netty:jar:3.10.6.Final:compile
[INFO] |  \- (com.google.guava:guava:jar:16.0.1:compile - omitted for duplicate)
[INFO] +- com.google.guava:guava:jar:16.0.1:compile
[INFO] +- javax.validation:validation-api:jar:1.1.0.Final:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.6.7:compile
[INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.6.7:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.6.7:compile
[INFO] |  +- (com.fasterxml.jackson.core:jackson-annotations:jar:2.6.0:compile - omitted for conflict with 2.6.7)
[INFO] |  \- (com.fasterxml.jackson.core:jackson-core:jar:2.6.7:compile - omitted for duplicate)
[INFO] +- junit:junit:jar:4.8.1:test
[INFO] +- org.easymock:easymock:jar:3.3:test
[INFO] |  +- cglib:cglib-nodep:jar:3.1:test
[INFO] |  \- org.objenesis:objenesis:jar:2.1:test
[INFO] +- org.slf4j:slf4j-simple:jar:1.7.25:test
[INFO] |  \- (org.slf4j:slf4j-api:jar:1.7.25:test - omitted for conflict with 1.7.22)
[INFO] \- com.metamx:http-client:test-jar:tests:1.1.0:test
[INFO]    +- (com.metamx:java-util:jar:0.28.2:test - omitted for duplicate)
[INFO]    +- (io.netty:netty:jar:3.10.6.Final:test - omitted for duplicate)
[INFO]    \- (com.google.guava:guava:jar:16.0.1:test - omitted for duplicate)
```

All tests passed without any modifications. No usages of incompatible API of updated libraries found.
