### PR TITLE
Updated plugins and dependencies versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
-            <version>3.3</version>
+            <version>3.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 
     <properties>
         <http-client.version>1.1.0</http-client.version>
-        <jackson.version>2.4.6</jackson.version>
+        <jackson.version>2.6.7</jackson.version>
     </properties>
 
     <dependencies>
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.1</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -130,7 +130,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>3.6.1</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>


### PR DESCRIPTION
Despite of using older version of jackson in driud we already updated jackson version to `2.6.7` in `java-util`. Also, spark is using `2.6.5` in `2.x` versions. I would suggest updating to `2.6.7` and test emitter with `2.4.6` in runtime. Looks like we use in emitter only backward compatible jackson API.