### PR TITLE
Move some logic from ParametrizedUriEmitterFactory to ParametrizedUriEmitter's constructor

### DIFF
--- a/src/main/java/com/metamx/emitter/core/ParametrizedUriEmitter.java
+++ b/src/main/java/com/metamx/emitter/core/ParametrizedUriEmitter.java
@@ -25,7 +25,7 @@ public class ParametrizedUriEmitter implements Flushable, Closeable, Emitter
     final String baseUri = config.getRecipientBaseUrlPattern();
     final ParametrizedUriExtractor parametrizedUriExtractor = new ParametrizedUriExtractor(baseUri);
     UriExtractor uriExtractor = parametrizedUriExtractor;
-    if (parametrizedUriExtractor.getParams().equals(ONLY_FEED_PARAM)) {
+    if (ONLY_FEED_PARAM.equals(parametrizedUriExtractor.getParams())) {
       uriExtractor = new FeedUriExtractor(baseUri.replace("{feed}", "%s"));
     }
     return uriExtractor;

--- a/src/main/java/com/metamx/emitter/core/factory/ParametrizedUriEmitterFactory.java
+++ b/src/main/java/com/metamx/emitter/core/factory/ParametrizedUriEmitterFactory.java
@@ -5,14 +5,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.metamx.common.lifecycle.Lifecycle;
 import com.metamx.emitter.core.Emitter;
-import com.metamx.emitter.core.FeedUriExtractor;
 import com.metamx.emitter.core.ParametrizedUriEmitter;
 import com.metamx.emitter.core.ParametrizedUriEmitterConfig;
-import com.metamx.emitter.core.ParametrizedUriExtractor;
-import com.metamx.emitter.core.UriExtractor;
 import com.metamx.http.client.HttpClient;
-import java.util.HashSet;
-import java.util.Set;
+
 import javax.validation.constraints.NotNull;
 
 public class ParametrizedUriEmitterFactory extends ParametrizedUriEmitterConfig implements EmitterFactory
@@ -26,20 +22,7 @@ public class ParametrizedUriEmitterFactory extends ParametrizedUriEmitterConfig 
   @Override
   public Emitter makeEmitter(ObjectMapper objectMapper, HttpClient httpClient, Lifecycle lifecycle)
   {
-    final String baseUri = getRecipientBaseUrlPattern();
-    final ParametrizedUriExtractor parametrizedUriExtractor = new ParametrizedUriExtractor(baseUri);
-    final Set<String> onlyFeedParam = new HashSet<>();
-    onlyFeedParam.add("feed");
-    UriExtractor uriExtractor = parametrizedUriExtractor;
-    if (parametrizedUriExtractor.getParams().equals(onlyFeedParam)) {
-      uriExtractor = new FeedUriExtractor(baseUri.replace("{feed}", "%s"));
-    }
-    final Emitter retVal = new ParametrizedUriEmitter(
-        this,
-        httpClient,
-        objectMapper,
-        uriExtractor
-    );
+    final Emitter retVal = new ParametrizedUriEmitter(this, httpClient, objectMapper);
     lifecycle.addManagedInstance(retVal);
     return retVal;
   }


### PR DESCRIPTION
This is needed in order not to re-implement the same logic on the Druid side, where factory is not used