### PR TITLE
Refactor HttpEmitterConfig and ParametrizedUriEmitterConfig

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
 
     <artifactId>emitter</artifactId>
-    <version>0.6.0-rc2-SNAPSHOT</version>
+    <version>0.6.0-rc2</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Emit events to logger or an http service</description>
@@ -51,7 +51,7 @@
         <connection>scm:git:ssh://git@github.com/metamx/emitter.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/metamx/emitter.git</developerConnection>
         <url>https://github.com/metamx/emitter.git</url>
-        <tag>HEAD</tag>
+        <tag>emitter-0.6.0-rc2</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
 
     <artifactId>emitter</artifactId>
-    <version>0.6.0-rc2</version>
+    <version>0.6.0-rc3-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Emit events to logger or an http service</description>
@@ -51,7 +51,7 @@
         <connection>scm:git:ssh://git@github.com/metamx/emitter.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/metamx/emitter.git</developerConnection>
         <url>https://github.com/metamx/emitter.git</url>
-        <tag>emitter-0.6.0-rc2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/src/main/java/com/metamx/emitter/core/BaseHttpEmittingConfig.java
+++ b/src/main/java/com/metamx/emitter/core/BaseHttpEmittingConfig.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.metamx.emitter.core;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.Min;
+
+public class BaseHttpEmittingConfig
+{
+  public static final long DEFAULT_FLUSH_MILLIS = 60 * 1000;
+  public static final int DEFAULT_FLUSH_COUNTS = 500;
+  public static final int DEFAULT_MAX_BATCH_SIZE = 5 * 1024 * 1024;
+  public static final long DEFAULT_MAX_BUFFER_SIZE = 250 * 1024 * 1024;
+  /** Do not time out in case flushTimeOut is not set */
+  public static final long DEFAULT_FLUSH_TIME_OUT = Long.MAX_VALUE;
+  public static final String DEFAULT_BASIC_AUTHENTICATION = null;
+  public static final BatchingStrategy DEFAULT_BATCHING_STRATEGY = BatchingStrategy.ARRAY;
+  public static final ContentEncoding DEFAULT_CONTENT_ENCODING = null;
+
+  @Min(1)
+  @JsonProperty
+  long flushMillis = DEFAULT_FLUSH_MILLIS;
+
+  @Min(0)
+  @JsonProperty
+  int flushCount = DEFAULT_FLUSH_COUNTS;
+
+  @Min(0)
+  @JsonProperty
+  long flushTimeOut = DEFAULT_FLUSH_TIME_OUT;
+
+  @JsonProperty
+  String basicAuthentication = DEFAULT_BASIC_AUTHENTICATION;
+
+  @JsonProperty
+  BatchingStrategy batchingStrategy = DEFAULT_BATCHING_STRATEGY;
+
+  @Min(0)
+  @JsonProperty
+  int maxBatchSize = DEFAULT_MAX_BATCH_SIZE;
+
+  @Min(0)
+  @JsonProperty
+  long maxBufferSize = DEFAULT_MAX_BUFFER_SIZE;
+
+  @JsonProperty
+  ContentEncoding contentEncoding = DEFAULT_CONTENT_ENCODING;
+
+  public long getFlushMillis()
+  {
+    return flushMillis;
+  }
+
+  public int getFlushCount()
+  {
+    return flushCount;
+  }
+
+  public long getFlushTimeOut() {
+    return flushTimeOut;
+  }
+
+  public String getBasicAuthentication()
+  {
+    return basicAuthentication;
+  }
+
+  public BatchingStrategy getBatchingStrategy()
+  {
+    return batchingStrategy;
+  }
+
+  public int getMaxBatchSize()
+  {
+    return maxBatchSize;
+  }
+
+  public long getMaxBufferSize()
+  {
+    return maxBufferSize;
+  }
+
+  public ContentEncoding getContentEncoding() {
+    return contentEncoding;
+  }
+}

--- a/src/main/java/com/metamx/emitter/core/HttpEmitterConfig.java
+++ b/src/main/java/com/metamx/emitter/core/HttpEmitterConfig.java
@@ -17,196 +17,33 @@
 package com.metamx.emitter.core;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import javax.validation.constraints.Min;
+
 import javax.validation.constraints.NotNull;
 
 /**
  */
-public class HttpEmitterConfig
+public class HttpEmitterConfig extends BaseHttpEmittingConfig
 {
-  private static final long DEFAULT_FLUSH_MILLIS = 60 * 1000;
-  private static final int DEFAULT_FLUSH_COUNTS = 500;
-  private static final String DEFAULT_RECIPIENT_BASE_URL = null;
-  private static final int DEFAULT_MAX_BATCH_SIZE = 5 * 1024 * 1024;
-  private static final long DEFAULT_MAX_BUFFER_SIZE = 250 * 1024 * 1024;
-  private static final long DEFAULT_FLUSH_TIME_OUT = Long.MAX_VALUE; // do not time out in case flushTimeOut is not set
-  private static final String DEFAULT_BASIC_AUTHENTICATION = null;
-  private static final BatchingStrategy DEFAULT_BATCHING_STRATEGY = BatchingStrategy.ARRAY;
-  private static final ContentEncoding DEFAULT_CONTENT_ENCODING = null;
-
-  @Min(1)
-  @JsonProperty
-  private long flushMillis = DEFAULT_FLUSH_MILLIS;
-
-  @Min(0)
-  @JsonProperty
-  private int flushCount = DEFAULT_FLUSH_COUNTS;
-
-  @Min(0)
-  @JsonProperty
-  private long flushTimeOut = DEFAULT_FLUSH_TIME_OUT;
-
   @NotNull
   @JsonProperty
-  private String recipientBaseUrl = DEFAULT_RECIPIENT_BASE_URL;
-
-  @JsonProperty
-  private String basicAuthentication = DEFAULT_BASIC_AUTHENTICATION;
-
-  @JsonProperty
-  private BatchingStrategy batchingStrategy = DEFAULT_BATCHING_STRATEGY;
-
-  @Min(0)
-  @JsonProperty
-  private int maxBatchSize = DEFAULT_MAX_BATCH_SIZE;
-
-  @Min(0)
-  @JsonProperty
-  private long maxBufferSize = DEFAULT_MAX_BUFFER_SIZE;
-
-  @JsonProperty
-  private ContentEncoding contentEncoding = DEFAULT_CONTENT_ENCODING;
+  String recipientBaseUrl = null;
 
   /**
    * For JSON deserialization only. In other cases use {@link Builder}
    */
   public HttpEmitterConfig() {}
 
-  /**
-   * @deprecated use {@link Builder}
-   */
-  @Deprecated
-  public HttpEmitterConfig(
-      long flushMillis,
-      int flushCount,
-      String recipientBaseUrl
-  )
+  public HttpEmitterConfig(BaseHttpEmittingConfig base, String recipientBaseUrl)
   {
-    this(
-        flushMillis,
-        flushCount,
-        DEFAULT_FLUSH_TIME_OUT,
-        recipientBaseUrl,
-        DEFAULT_BASIC_AUTHENTICATION,
-        DEFAULT_BATCHING_STRATEGY,
-        DEFAULT_MAX_BATCH_SIZE,
-        DEFAULT_MAX_BUFFER_SIZE
-    );
-  }
-
-  /**
-   * @deprecated use {@link Builder}
-   */
-  @Deprecated
-  public HttpEmitterConfig(
-      long flushMillis,
-      int flushCount,
-      String recipientBaseUrl,
-      int maxBatchSize,
-      long maxBufferSize
-  )
-  {
-    this(
-        flushMillis,
-        flushCount,
-        DEFAULT_FLUSH_TIME_OUT,
-        recipientBaseUrl,
-        DEFAULT_BASIC_AUTHENTICATION,
-        DEFAULT_BATCHING_STRATEGY,
-        maxBatchSize,
-        maxBufferSize
-    );
-  }
-
-  /**
-   * @deprecated use {@link Builder}
-   */
-  @Deprecated
-  public HttpEmitterConfig(
-      long flushMillis,
-      int flushCount,
-      String recipientBaseUrl,
-      String basicAuthentication,
-      BatchingStrategy batchingStrategy,
-      int maxBatchSize,
-      long maxBufferSize
-  )
-  {
-    this(
-        flushMillis,
-        flushCount,
-        DEFAULT_FLUSH_TIME_OUT,
-        recipientBaseUrl,
-        basicAuthentication,
-        batchingStrategy,
-        maxBatchSize,
-        maxBufferSize
-    );
-  }
-
-  /**
-   * @deprecated use {@link Builder}
-   */
-  @Deprecated
-  public HttpEmitterConfig(
-      long flushMillis,
-      int flushCount,
-      long flushTimeOut,
-      String recipientBaseUrl,
-      String basicAuthentication,
-      BatchingStrategy batchingStrategy,
-      int maxBatchSize,
-      long maxBufferSize
-  )
-  {
-    this(
-        flushMillis,
-        flushCount,
-        flushTimeOut,
-        recipientBaseUrl,
-        basicAuthentication,
-        batchingStrategy,
-        maxBatchSize,
-        maxBufferSize,
-        DEFAULT_CONTENT_ENCODING
-    );
-  }
-
-  private HttpEmitterConfig(
-      long flushMillis,
-      int flushCount,
-      long flushTimeOut,
-      String recipientBaseUrl,
-      String basicAuthentication,
-      BatchingStrategy batchingStrategy,
-      int maxBatchSize,
-      long maxBufferSize,
-      ContentEncoding contentEncoding
-  )
-  {
-    this.flushMillis = flushMillis;
-    this.flushCount = flushCount;
-    this.flushTimeOut = flushTimeOut;
+    this.flushMillis = base.flushMillis;
+    this.flushCount = base.flushCount;
+    this.flushTimeOut = base.flushTimeOut;
     this.recipientBaseUrl = recipientBaseUrl;
-    this.basicAuthentication = basicAuthentication;
-    this.batchingStrategy = batchingStrategy;
-    this.maxBatchSize = maxBatchSize;
-    this.maxBufferSize = maxBufferSize;
-    this.contentEncoding = contentEncoding;
-  }
-
-  public long getFlushMillis()
-  {
-    return flushMillis;
-  }
-
-  public int getFlushCount()
-  {
-    return flushCount;
-  }
-
-  public long getFlushTimeOut() {
-    return flushTimeOut;
+    this.basicAuthentication = base.basicAuthentication;
+    this.batchingStrategy = base.batchingStrategy;
+    this.maxBatchSize = base.maxBatchSize;
+    this.maxBufferSize = base.maxBufferSize;
+    this.contentEncoding = base.contentEncoding;
   }
 
   public String getRecipientBaseUrl()
@@ -214,59 +51,11 @@ public class HttpEmitterConfig
     return recipientBaseUrl;
   }
 
-  public String getBasicAuthentication()
+  public static class Builder extends HttpEmitterConfig
   {
-    return basicAuthentication;
-  }
-
-  public BatchingStrategy getBatchingStrategy()
-  {
-    return batchingStrategy;
-  }
-
-  public int getMaxBatchSize()
-  {
-    return maxBatchSize;
-  }
-
-  public long getMaxBufferSize()
-  {
-    return maxBufferSize;
-  }
-
-  public ContentEncoding getContentEncoding() {
-    return contentEncoding;
-  }
-
-  public static class Builder
-  {
-    private long flushMillis = DEFAULT_FLUSH_MILLIS;
-    private int flushCount = DEFAULT_FLUSH_COUNTS;
-    private String recipientBaseUrl = DEFAULT_RECIPIENT_BASE_URL;
-    private long flushTimeOut = DEFAULT_FLUSH_TIME_OUT;
-    private String basicAuthentication = DEFAULT_BASIC_AUTHENTICATION;
-    private BatchingStrategy batchingStrategy = DEFAULT_BATCHING_STRATEGY;
-    private int maxBatchSize = DEFAULT_MAX_BATCH_SIZE;
-    private long maxBufferSize = DEFAULT_MAX_BUFFER_SIZE;
-    private ContentEncoding contentEncoding = DEFAULT_CONTENT_ENCODING;
-
     public Builder(String recipientBaseUrl)
     {
       this.recipientBaseUrl = recipientBaseUrl;
-    }
-
-    public Builder copyWithRecipientBaseUrl(String recipientBaseUrl)
-    {
-      Builder b = new Builder(recipientBaseUrl);
-      b.setBasicAuthentication(this.basicAuthentication)
-       .setBatchingStrategy(this.batchingStrategy)
-       .setContentEncoding(this.contentEncoding)
-       .setFlushCount(this.flushCount)
-       .setFlushMillis(this.flushMillis)
-       .setFlushTimeOut(this.flushTimeOut)
-       .setMaxBatchSize(this.maxBatchSize)
-       .setMaxBufferSize(this.maxBufferSize);
-      return b;
     }
 
     public Builder setFlushMillis(long flushMillis)
@@ -319,17 +108,7 @@ public class HttpEmitterConfig
 
     public HttpEmitterConfig build()
     {
-      return new HttpEmitterConfig(
-          flushMillis,
-          flushCount,
-          flushTimeOut,
-          recipientBaseUrl,
-          basicAuthentication,
-          batchingStrategy,
-          maxBatchSize,
-          maxBufferSize,
-          contentEncoding
-      );
+      return new HttpEmitterConfig(this, recipientBaseUrl);
     }
   }
 }

--- a/src/main/java/com/metamx/emitter/core/ParametrizedUriEmitterConfig.java
+++ b/src/main/java/com/metamx/emitter/core/ParametrizedUriEmitterConfig.java
@@ -1,19 +1,17 @@
 package com.metamx.emitter.core;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import javax.validation.constraints.NotNull;
 
-public class ParametrizedUriEmitterConfig extends HttpEmitterConfig.Builder
+public class ParametrizedUriEmitterConfig
 {
+  @NotNull
+  @JsonProperty
   private String recipientBaseUrlPattern;
 
-  @JsonCreator
-  public ParametrizedUriEmitterConfig(@NotNull @JsonProperty("recipientBaseUrlPattern") String recipientBaseUrlPattern)
-  {
-    super(null);
-    this.recipientBaseUrlPattern = recipientBaseUrlPattern;
-  }
+  @JsonProperty("httpEmitting")
+  private BaseHttpEmittingConfig httpEmittingConfig;
 
   public String getRecipientBaseUrlPattern()
   {
@@ -22,6 +20,6 @@ public class ParametrizedUriEmitterConfig extends HttpEmitterConfig.Builder
 
   public HttpEmitterConfig buildHttpEmitterConfig(String baseUri)
   {
-    return copyWithRecipientBaseUrl(baseUri).build();
+    return new HttpEmitterConfig(httpEmittingConfig, baseUri);
   }
 }

--- a/src/main/java/com/metamx/emitter/core/ParametrizedUriEmitterConfig.java
+++ b/src/main/java/com/metamx/emitter/core/ParametrizedUriEmitterConfig.java
@@ -6,12 +6,14 @@ import javax.validation.constraints.NotNull;
 
 public class ParametrizedUriEmitterConfig
 {
+  private static final BaseHttpEmittingConfig DEFAULT_HTTP_EMITTING_CONFIG = new BaseHttpEmittingConfig();
+
   @NotNull
   @JsonProperty
   private String recipientBaseUrlPattern;
 
   @JsonProperty("httpEmitting")
-  private BaseHttpEmittingConfig httpEmittingConfig;
+  private BaseHttpEmittingConfig httpEmittingConfig = DEFAULT_HTTP_EMITTING_CONFIG;
 
   public String getRecipientBaseUrlPattern()
   {

--- a/src/main/java/com/metamx/emitter/core/factory/HttpEmitterFactory.java
+++ b/src/main/java/com/metamx/emitter/core/factory/HttpEmitterFactory.java
@@ -9,7 +9,6 @@ import com.metamx.http.client.HttpClient;
 
 public class HttpEmitterFactory extends HttpEmitterConfig implements EmitterFactory
 {
-  public HttpEmitterFactory() {}
 
   @Override
   public Emitter makeEmitter(ObjectMapper objectMapper, HttpClient httpClient, Lifecycle lifecycle)

--- a/src/main/java/com/metamx/emitter/core/factory/ParametrizedUriEmitterFactory.java
+++ b/src/main/java/com/metamx/emitter/core/factory/ParametrizedUriEmitterFactory.java
@@ -1,7 +1,5 @@
 package com.metamx.emitter.core.factory;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.metamx.common.lifecycle.Lifecycle;
 import com.metamx.emitter.core.Emitter;
@@ -9,15 +7,8 @@ import com.metamx.emitter.core.ParametrizedUriEmitter;
 import com.metamx.emitter.core.ParametrizedUriEmitterConfig;
 import com.metamx.http.client.HttpClient;
 
-import javax.validation.constraints.NotNull;
-
 public class ParametrizedUriEmitterFactory extends ParametrizedUriEmitterConfig implements EmitterFactory
 {
-  @JsonCreator
-  public ParametrizedUriEmitterFactory(@NotNull @JsonProperty("recipientBaseUrlPattern") String recipientBaseUrlPattern)
-  {
-    super(recipientBaseUrlPattern);
-  }
 
   @Override
   public Emitter makeEmitter(ObjectMapper objectMapper, HttpClient httpClient, Lifecycle lifecycle)

--- a/src/test/java/com/metamx/emitter/core/HttpPostEmitterStressTest.java
+++ b/src/test/java/com/metamx/emitter/core/HttpPostEmitterStressTest.java
@@ -58,15 +58,13 @@ public class HttpPostEmitterStressTest
   @Test
   public void eventCountBased() throws InterruptedException, IOException
   {
-    HttpEmitterConfig config = new HttpEmitterConfig(
-        100,
-        4,
-        "http://foo.bar",
-        null,
-        BatchingStrategy.ONLY_EVENTS,
-        1024 * 1024,
-        1024 * 1024
-    );
+    HttpEmitterConfig config = new HttpEmitterConfig.Builder("http://foo.bar")
+        .setFlushMillis(100)
+        .setFlushCount(4)
+        .setBatchingStrategy(BatchingStrategy.ONLY_EVENTS)
+        .setMaxBatchSize(1024 * 1024)
+        .setMaxBufferSize(1024 * 1024)
+        .build();
     final HttpPostEmitter emitter = new HttpPostEmitter(config, httpClient, objectMapper);
     int nThreads = Runtime.getRuntime().availableProcessors() * 2;
     final List<IntList> eventsPerThread = new ArrayList<>(nThreads);

--- a/src/test/java/com/metamx/emitter/core/ParametrizedUriEmitterConfigTest.java
+++ b/src/test/java/com/metamx/emitter/core/ParametrizedUriEmitterConfigTest.java
@@ -31,13 +31,13 @@ public class ParametrizedUriEmitterConfigTest
   public void testSettingEverything()
   {
     final Properties props = new Properties();
-    props.setProperty("com.metamx.emitter.flushMillis", "1");
-    props.setProperty("com.metamx.emitter.flushCount", "2");
-    props.setProperty("com.metamx.emitter.basicAuthentication", "a:b");
-    props.setProperty("com.metamx.emitter.batchingStrategy", "NEWLINES");
-    props.setProperty("com.metamx.emitter.maxBatchSize", "4");
-    props.setProperty("com.metamx.emitter.maxBufferSize", "8");
-    props.setProperty("com.metamx.emitter.flushTimeOut", "1000");
+    props.setProperty("com.metamx.emitter.httpEmitting.flushMillis", "1");
+    props.setProperty("com.metamx.emitter.httpEmitting.flushCount", "2");
+    props.setProperty("com.metamx.emitter.httpEmitting.basicAuthentication", "a:b");
+    props.setProperty("com.metamx.emitter.httpEmitting.batchingStrategy", "NEWLINES");
+    props.setProperty("com.metamx.emitter.httpEmitting.maxBatchSize", "4");
+    props.setProperty("com.metamx.emitter.httpEmitting.maxBufferSize", "8");
+    props.setProperty("com.metamx.emitter.httpEmitting.flushTimeOut", "1000");
 
     final ObjectMapper objectMapper = new ObjectMapper();
     final ParametrizedUriEmitterConfig paramConfig = objectMapper.convertValue(Emitters.makeCustomFactoryMap(props), ParametrizedUriEmitterConfig.class);


### PR DESCRIPTION
 - Instead of subclassing `ParametrizedUriEmitterConfig` from `HttpEmitterConfig.Builder`, extract `BaseHttpEmittingConfig` superclass from `HttpEmitterConfig` and make it a nested field of `ParametrizedUriEmitterConfig`. @isimonenko have chosen to go the original way to keep `ParametrizedUriEmitterConfig` "flat", but I see nothing bad about have another level of nesting. In fact it more accurately models the config relations, and makes it more evident that Parametrized uses HttpPostEmitter under the hood. So instead of
```
xxx.parametrized.recipientBaseUrlPattern=...
xxx.parametrized.basicAuthentication=...
xxx.parametrized.batchingStrategy=...
```
it will be
```
xxx.parametrized.recipientBaseUrlPattern=...
xxx.parametrized.httpEmitting.basicAuthentication=...
xxx.parametrized.httpEmitting.batchingStrategy=...
```

 - Remove deprecated constructors in HttpEmitterConfig