### PR TITLE
Make ParametrizedUriEmitter.start() and close() idempotent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
 
     <artifactId>emitter</artifactId>
-    <version>0.6.0-rc3-SNAPSHOT</version>
+    <version>0.6.0-rc3</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Emit events to logger or an http service</description>
@@ -51,7 +51,7 @@
         <connection>scm:git:ssh://git@github.com/metamx/emitter.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/metamx/emitter.git</developerConnection>
         <url>https://github.com/metamx/emitter.git</url>
-        <tag>HEAD</tag>
+        <tag>emitter-0.6.0-rc3</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
 
     <artifactId>emitter</artifactId>
-    <version>0.6.0-rc3</version>
+    <version>0.6.0-rc4-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Emit events to logger or an http service</description>
@@ -51,7 +51,7 @@
         <connection>scm:git:ssh://git@github.com/metamx/emitter.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/metamx/emitter.git</developerConnection>
         <url>https://github.com/metamx/emitter.git</url>
-        <tag>emitter-0.6.0-rc3</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>


### PR DESCRIPTION
`Closeable` contract requires `close()` to be idempotent. The fact that `start()` is not idempotent actually causes problems in Druid. Other Emitter have those ops idempotent already.